### PR TITLE
Migrate HyperProtect-Mixin to Hytale server 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet*
 
+## [1.3.0] - 2026-06-05
+
+**Server Version:** `0.5.3`
+
+Hytale **0.5.3** (the "Update 5" release line) carried major internal API changes. This
+release migrates all 29 mixin interceptors to compile and apply cleanly on 0.5.3. Verified
+against the live 0.5.3 server (Hyxin, standalone mode): all 29 mixins active with zero apply
+failures and the bridge initialized.
+
+### Changed
+- **Vectors moved to JOML** — `com.hypixel.hytale.math.vector.Vector3d/3f/3i` → `org.joml.*`;
+  accessors `getX()/getY()/getZ()` → `x()/y()/z()`. Updated imports, redirect descriptors, and
+  `@Shadow`/handler signatures across Harvest, Explosion, BlockPlace, ProximityLoot, DeathLoot,
+  Wear, EntityDamage, ProjectileLaunch, NpcAdditionGate, Mount, Respawn, SimpleBlockInteractionGate,
+  SimpleInstantInteractionGate, and CaptureCrateGate. (`Transform`, `Rotation3f`, and `Box` stay in
+  `com.hypixel.hytale.math.*`.)
+- **`Player` is no longer a `CommandSender`** — `sendMessage(Message)` / `hasPermission(String)`
+  moved to `PlayerRef`; all deny-message paths now route through `PlayerRef`.
+- **Manifest** — `ServerVersion` is templated as `^${serverVersion}` (`^0.5.3`); the 0.5.x
+  SemverRange codec rejects a bare non-zero-patch version.
+
+### Fixed (per interceptor)
+- **ExplosionInterceptor** — the inner `BlockHarvestUtils.performBlockDamage` dropped its leading
+  `LivingEntity` param; rewrote the `method=` and `@At` descriptors and the handler, and now detects
+  sourceless (explosion) block damage via `ref == null` (the 8-arg overload always forwards `ref = null`).
+- **BlockPlaceInterceptor** — `BlockPlaceUtils.placeBlock` is now 15 args: the `Inventory` param was
+  removed and two trailing booleans (`quickRetype`, `noPhysics`) were added next to `quickReplace`, with
+  both block vectors now `org.joml.Vector3i`. Rewrote the redirect descriptor and pass-through.
+- **WearInterceptor** — `Player` no longer overrides `updateItemStackDurability` and the impl moved to
+  the static `ItemUtils.updateItemStackDurability`. Retargeted `@Mixin(LivingEntity)` and redirect that
+  static call; the allow path re-invokes the static impl (no recursion), so the v1.2.4 inlining workaround
+  was removed.
+- **ProjectileLaunchInterceptor** — `ProjectileModule.spawnProjectile` gained a 6-arg `(UUID, …)` overload
+  and the 5-arg one only delegates to it, so the old `method="*"` + 5-arg redirect matched no call site.
+  Retargeted the 6-arg overload and redirect its `commandBuffer.addEntity(holder, SPAWN)` — the point every
+  launch path converges on — reading creator/world/position from the enclosing params.
+- **NpcAdditionGate** — `NPCPlugin.spawnEntity` now takes `org.joml.Vector3dc` + `Rotation3fc` (not
+  `math.vector.Vector3d`/`Vector3f`); updated the `method=` descriptor.
+- **RespawnInterceptor** — `Player.tryUseSpawnPoint`'s 5th parameter changed `Player` → `PlayerRef`;
+  updated the `@Shadow` stub, the `@Redirect` descriptor, and the handler.
+- **MarkerSpawnGate / ChunkSpawnGate** — `SpawningContext.world` is now private; read it via `getWorld()`.
+- **CommandGateInterceptor** — the command sender is now a `PlayerRef` (not a `Player`); match `PlayerRef`,
+  resolve the `Player` component from it to keep the `evaluateCommand(Player, String)` bridge contract
+  unchanged, and message via `PlayerRef`.
+- **MapMarkerFilter** — corrected the `MapMarker` parameter package in the `addIgnoreViewDistance` redirect
+  descriptor (`com.hypixel.hytale.protocol.packets.worldmap.MapMarker`).
+- **SharedMarkerFilter** — `SharedMarkersProvider.update` now emits via `addIgnoreViewDistance` (not `add`);
+  retargeted the `@Redirect` and the handler's re-emit calls.
+- **ChainDesyncFilter** — `InteractionChain.addTempSyncData` was renamed to `putInteractionSyncData`;
+  updated the `method=` selector.
+
+### Notes
+- The 30-slot bridge protocol and verdict contract are unchanged (HyperFactions 0.14.0 consumes them);
+  the OG-coexistence `SAFE_MIXINS` set (14) and `totalMixins = 29` are unchanged.
+- `FlameTickInterceptor`, `BenchPositionCapture`, `EntityLoadGate`, `PrefabSpawnInterceptor`,
+  `SpawnLogFilter`, and `EntryDesyncFilter` required no changes — their descriptors were verified
+  unchanged on 0.5.3 via `javap`.
+
 ## [1.2.4] - 2026-04-02
 
 **Server Version:** `2026.03.26-89796e57b`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 Server-level event interception via Hyxin mixins for Hytale. Provides a lock-free bridge API that any mod can use to intercept and control server actions — no compile-time dependency required.
 
-**Version:** 1.2.2
+**Version:** 1.3.0
+**Server Version:** `0.5.3`
 **Platform:** Hytale Early Access
 **Type:** Hyxin Early Plugin
 **License:** GPLv3
@@ -208,7 +209,7 @@ HyperProtect-Mixin requires **zero configuration**. It auto-detects and initiali
 | Property | Value | Purpose |
 |----------|-------|---------|
 | `hyperprotect.bridge.active` | `"true"` | Bridge initialized |
-| `hyperprotect.bridge.version` | `"1.2.2"` | Bridge version |
+| `hyperprotect.bridge.version` | `"1.3.0"` | Bridge version |
 | `hyperprotect.mode` | `"standalone"` or `"compatible"` | Operating mode (compatible when OrbisGuard-Mixins detected) |
 | `hyperprotect.intercept.*` | `"true"` | Per-interceptor load confirmation |
 
@@ -227,7 +228,7 @@ See [docs/feature-detection.md](docs/feature-detection.md) for the full list.
 ./gradlew jar
 ```
 
-Output: `build/libs/HyperProtect-Mixin-1.2.2.jar`
+Output: `build/libs/HyperProtect-Mixin-1.3.0.jar`
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.hyperprotect'
-version = '1.2.4'
+version = '1.3.0'
 
 // Resolve Hytale server version from Maven
 def hytaleChannel = (findProperty('hytale_channel') ?: 'release').toString().trim()

--- a/src/main/java/com/hyperprotect/mixin/intercept/building/BlockPlaceInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/building/BlockPlaceInterceptor.java
@@ -2,13 +2,11 @@ package com.hyperprotect.mixin.intercept.building;
 
 import com.hypixel.hytale.component.ComponentAccessor;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3i;
+import org.joml.Vector3i;
 import com.hypixel.hytale.protocol.BlockRotation;
 import com.hypixel.hytale.protocol.InteractionState;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.entity.InteractionContext;
-import com.hypixel.hytale.server.core.entity.entities.Player;
-import com.hypixel.hytale.server.core.inventory.Inventory;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
 import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
 import com.hypixel.hytale.server.core.modules.interaction.BlockPlaceUtils;
@@ -155,7 +153,7 @@ public class BlockPlaceInterceptor {
     @Redirect(
         method = "tick0",
         at = @At(value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/modules/interaction/BlockPlaceUtils;placeBlock(Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Ljava/lang/String;Lcom/hypixel/hytale/server/core/inventory/container/ItemContainer;Lcom/hypixel/hytale/math/vector/Vector3i;Lcom/hypixel/hytale/math/vector/Vector3i;Lcom/hypixel/hytale/protocol/BlockRotation;Lcom/hypixel/hytale/server/core/inventory/Inventory;BZLcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/ComponentAccessor;Lcom/hypixel/hytale/component/ComponentAccessor;Z)V")
+            target = "Lcom/hypixel/hytale/server/core/modules/interaction/BlockPlaceUtils;placeBlock(Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Ljava/lang/String;Lcom/hypixel/hytale/server/core/inventory/container/ItemContainer;Lorg/joml/Vector3i;Lorg/joml/Vector3i;Lcom/hypixel/hytale/protocol/BlockRotation;BZLcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/ComponentAccessor;Lcom/hypixel/hytale/component/ComponentAccessor;ZZZ)V")
     )
     private void gatePlaceBlock(Ref<EntityStore> ref,
                                 ItemStack itemStack,
@@ -164,13 +162,14 @@ public class BlockPlaceInterceptor {
                                 Vector3i placementNormal,
                                 Vector3i blockPosition,
                                 BlockRotation blockRotation,
-                                @Nullable Inventory inventory,
                                 byte activeSlot,
                                 boolean removeItemInHand,
                                 Ref<ChunkStore> chunkReference,
                                 ComponentAccessor<ChunkStore> chunkStore,
                                 ComponentAccessor<EntityStore> entityStore,
-                                boolean quickReplace) {
+                                boolean quickReplace,
+                                boolean quickRetype,
+                                boolean noPhysics) {
         try {
             Object[] hook = resolveHook();
             if (hook != null) {
@@ -182,19 +181,16 @@ public class BlockPlaceInterceptor {
 
                     int verdict = (int) ((MethodHandle) hook[1]).invoke(
                             hook[0], playerUuid, worldName,
-                            blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
+                            blockPosition.x(), blockPosition.y(), blockPosition.z());
 
                     if (verdict == 1 || verdict == 2 || verdict == 3) {
                         // Denied — send message if DENY_WITH_MESSAGE
                         if (verdict == 1 && hook.length >= 3 && hook[2] != null) {
                             String reason = (String) ((MethodHandle) hook[2]).invoke(
                                     hook[0], playerUuid, worldName,
-                                    blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
-                            Player player = entityStore.getComponent(ref, Player.getComponentType());
-                            if (player != null) {
-                                Message msg = formatReason(reason);
-                                if (msg != null) player.sendMessage(msg);
-                            }
+                                    blockPosition.x(), blockPosition.y(), blockPosition.z());
+                            Message msg = formatReason(reason);
+                            if (msg != null) playerRef.sendMessage(msg);
                         }
 
                         // Set interaction state to Failed via captured context
@@ -213,7 +209,8 @@ public class BlockPlaceInterceptor {
 
         // Allowed — call original
         BlockPlaceUtils.placeBlock(ref, itemStack, blockTypeKey, itemContainer,
-                placementNormal, blockPosition, blockRotation, inventory,
-                activeSlot, removeItemInHand, chunkReference, chunkStore, entityStore, quickReplace);
+                placementNormal, blockPosition, blockRotation,
+                activeSlot, removeItemInHand, chunkReference, chunkStore, entityStore,
+                quickReplace, quickRetype, noPhysics);
     }
 }

--- a/src/main/java/com/hyperprotect/mixin/intercept/building/ExplosionInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/building/ExplosionInterceptor.java
@@ -2,9 +2,8 @@ package com.hyperprotect.mixin.intercept.building;
 
 import com.hypixel.hytale.component.ComponentAccessor;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3i;
+import org.joml.Vector3i;
 import com.hypixel.hytale.server.core.asset.type.item.config.ItemTool;
-import com.hypixel.hytale.server.core.entity.LivingEntity;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
 import com.hypixel.hytale.server.core.modules.interaction.BlockHarvestUtils;
 import com.hypixel.hytale.server.core.universe.world.World;
@@ -72,14 +71,13 @@ public class ExplosionInterceptor {
     }
 
     @Redirect(
-        method = "performBlockDamage(Lcom/hypixel/hytale/math/vector/Vector3i;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/server/core/asset/type/item/config/ItemTool;FILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/CommandBuffer;Lcom/hypixel/hytale/component/ComponentAccessor;)Z",
+        method = "performBlockDamage(Lorg/joml/Vector3i;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/server/core/asset/type/item/config/ItemTool;FILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/ComponentAccessor;Lcom/hypixel/hytale/component/ComponentAccessor;)Z",
         at = @At(
             value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/modules/interaction/BlockHarvestUtils;performBlockDamage(Lcom/hypixel/hytale/server/core/entity/LivingEntity;Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/math/vector/Vector3i;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/server/core/asset/type/item/config/ItemTool;Ljava/lang/String;ZFILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/ComponentAccessor;Lcom/hypixel/hytale/component/ComponentAccessor;)Z"
+            target = "Lcom/hypixel/hytale/server/core/modules/interaction/BlockHarvestUtils;performBlockDamage(Lcom/hypixel/hytale/component/Ref;Lorg/joml/Vector3i;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/server/core/asset/type/item/config/ItemTool;Ljava/lang/String;ZFILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/ComponentAccessor;Lcom/hypixel/hytale/component/ComponentAccessor;)Z"
         )
     )
     private static boolean redirectExplosionBlockDamage(
-            @Nullable LivingEntity entity,
             @Nullable Ref<EntityStore> ref,
             @Nonnull Vector3i targetBlockPos,
             @Nullable ItemStack itemStack,
@@ -92,8 +90,11 @@ public class ExplosionInterceptor {
             @Nonnull ComponentAccessor<EntityStore> entityStore,
             @Nonnull ComponentAccessor<ChunkStore> chunkStore) {
 
-        // Only intercept explosions (no entity source)
-        if (entity == null && ref == null) {
+        // In 0.5.3 the inner performBlockDamage lost its leading LivingEntity param.
+        // The 8-arg overload (the sourceless/physics entry point this redirect lives
+        // in) always forwards ref=null to the 11-arg impl, so a null ref identifies an
+        // explosion-style block break with no entity source.
+        if (ref == null) {
             try {
                 int verdict = queryExplosionVerdict(entityStore, targetBlockPos);
                 if (verdict != 0) {
@@ -106,7 +107,7 @@ public class ExplosionInterceptor {
         }
 
         return BlockHarvestUtils.performBlockDamage(
-                entity, ref, targetBlockPos, itemStack, tool, toolId,
+                ref, targetBlockPos, itemStack, tool, toolId,
                 matchTool, damageScale, setBlockSettings, chunkReference,
                 entityStore, chunkStore);
     }
@@ -142,7 +143,7 @@ public class ExplosionInterceptor {
 
         int verdict = (int) ((MethodHandle) cached[1]).invoke(
                 cached[0], world,
-                targetBlockPos.getX(), targetBlockPos.getY(), targetBlockPos.getZ());
+                targetBlockPos.x(), targetBlockPos.y(), targetBlockPos.z());
 
         // Fail-open for negative/unknown values
         return verdict < 0 ? 0 : verdict;

--- a/src/main/java/com/hyperprotect/mixin/intercept/building/HarvestInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/building/HarvestInterceptor.java
@@ -2,8 +2,8 @@ package com.hyperprotect.mixin.intercept.building;
 
 import com.hypixel.hytale.component.ComponentAccessor;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3d;
-import com.hypixel.hytale.math.vector.Vector3i;
+import org.joml.Vector3d;
+import org.joml.Vector3i;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.asset.type.blocktype.config.BlockType;
 import com.hypixel.hytale.server.core.entity.ItemUtils;
@@ -264,14 +264,14 @@ public abstract class HarvestInterceptor {
                 if (hook != null) {
                     int verdict = (int) ((MethodHandle) hook[1]).invoke(
                             hook[0], playerUuid, worldName,
-                            targetBlock.getX(), targetBlock.getY(), targetBlock.getZ());
+                            targetBlock.x(), targetBlock.y(), targetBlock.z());
 
                     if (verdict == DENY_WITH_MESSAGE || verdict == DENY_SILENT || verdict == DENY_MOD_HANDLES) {
                         String reason = null;
                         if (verdict == DENY_WITH_MESSAGE && hook.length >= 3 && hook[2] != null) {
                             reason = (String) ((MethodHandle) hook[2]).invoke(
                                     hook[0], playerUuid, worldName,
-                                    targetBlock.getX(), targetBlock.getY(), targetBlock.getZ());
+                                    targetBlock.x(), targetBlock.y(), targetBlock.z());
                         }
                         ctx = context.get();
                         if (ctx != null) {
@@ -291,7 +291,7 @@ public abstract class HarvestInterceptor {
      */
     @Redirect(
         method = "performPickupByInteraction",
-        at = @At(value = "INVOKE", target = "Lcom/hypixel/hytale/server/core/modules/interaction/BlockHarvestUtils;removeBlock(Lcom/hypixel/hytale/math/vector/Vector3i;Lcom/hypixel/hytale/server/core/asset/type/blocktype/config/BlockType;ILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/ComponentAccessor;)V")
+        at = @At(value = "INVOKE", target = "Lcom/hypixel/hytale/server/core/modules/interaction/BlockHarvestUtils;removeBlock(Lorg/joml/Vector3i;Lcom/hypixel/hytale/server/core/asset/type/blocktype/config/BlockType;ILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/ComponentAccessor;)V")
     )
     private static void interceptRemoval(Vector3i blockPosition, BlockType blockType,
                                          int setBlockSettings, Ref<ChunkStore> chunkReference,
@@ -304,9 +304,9 @@ public abstract class HarvestInterceptor {
             try {
                 BlockChunk blockChunk = (BlockChunk) chunkStore.getComponent(chunkReference, BlockChunk.getComponentType());
                 if (blockChunk != null) {
-                    BlockSection section = blockChunk.getSectionAtBlockY(blockPosition.getY());
+                    BlockSection section = blockChunk.getSectionAtBlockY(blockPosition.y());
                     if (section != null) {
-                        section.invalidateBlock(blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
+                        section.invalidateBlock(blockPosition.x(), blockPosition.y(), blockPosition.z());
                     }
                 }
             } catch (Exception ignored) {
@@ -318,7 +318,7 @@ public abstract class HarvestInterceptor {
                     Player player = ctx.actor();
                     Message msg = formatReason(ctx.reason());
                     if (player != null && msg != null) {
-                        player.sendMessage(msg);
+                        player.getPlayerRef().sendMessage(msg);
                     }
                 } catch (Exception ignored) {
                 }
@@ -334,7 +334,7 @@ public abstract class HarvestInterceptor {
      */
     @Redirect(
         method = "performPickupByInteraction",
-        at = @At(value = "INVOKE", target = "Lcom/hypixel/hytale/server/core/entity/ItemUtils;interactivelyPickupItem(Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/math/vector/Vector3d;Lcom/hypixel/hytale/component/ComponentAccessor;)V")
+        at = @At(value = "INVOKE", target = "Lcom/hypixel/hytale/server/core/entity/ItemUtils;interactivelyPickupItem(Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lorg/joml/Vector3d;Lcom/hypixel/hytale/component/ComponentAccessor;)V")
     )
     private static void interceptCollection(Ref<EntityStore> ref, ItemStack itemStack,
                                             Vector3d origin, ComponentAccessor<EntityStore> componentAccessor) {
@@ -358,18 +358,18 @@ public abstract class HarvestInterceptor {
                 if (hook != null) {
                     int pickupVerdict = (int) ((MethodHandle) hook[1]).invoke(
                             hook[0], playerUuid, worldName,
-                            (int) origin.getX(), (int) origin.getY(), (int) origin.getZ());
+                            (int) origin.x(), (int) origin.y(), (int) origin.z());
 
                     if (pickupVerdict == DENY_WITH_MESSAGE || pickupVerdict == DENY_SILENT || pickupVerdict == DENY_MOD_HANDLES) {
                         // Send message for DENY_WITH_MESSAGE
                         if (pickupVerdict == DENY_WITH_MESSAGE && hook.length >= 3 && hook[2] != null) {
                             String reason = (String) ((MethodHandle) hook[2]).invoke(
                                     hook[0], playerUuid, worldName,
-                                    (int) origin.getX(), (int) origin.getY(), (int) origin.getZ());
+                                    (int) origin.x(), (int) origin.y(), (int) origin.z());
                             Player player = (Player) componentAccessor.getComponent(ref, Player.getComponentType());
                             Message msg = formatReason(reason);
                             if (player != null && msg != null) {
-                                player.sendMessage(msg);
+                                player.getPlayerRef().sendMessage(msg);
                             }
                         }
                         return;

--- a/src/main/java/com/hyperprotect/mixin/intercept/building/PasteInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/building/PasteInterceptor.java
@@ -6,7 +6,6 @@ import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.protocol.packets.buildertools.BuilderToolPasteClipboard;
 import com.hypixel.hytale.server.core.Message;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
@@ -150,9 +149,8 @@ public abstract class PasteInterceptor {
                         String reason = (String) ((MethodHandle) hook[2]).invoke(
                                 hook[0], playerUuid, worldName,
                                 packet.x, packet.y, packet.z);
-                        Player player = (Player) result;
                         Message msg = formatReason(reason);
-                        if (msg != null) player.sendMessage(msg);
+                        if (msg != null) playerRef.sendMessage(msg);
                     }
                     return null; // Return null to trigger early exit
                 }

--- a/src/main/java/com/hyperprotect/mixin/intercept/combat/EntityDamageInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/combat/EntityDamageInterceptor.java
@@ -2,13 +2,12 @@ package com.hyperprotect.mixin.intercept.combat;
 
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.protocol.InteractionState;
 import com.hypixel.hytale.protocol.InteractionType;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.entity.EntitySnapshot;
 import com.hypixel.hytale.server.core.entity.InteractionContext;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.CooldownHandler;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.server.DamageEntityInteraction;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
@@ -113,7 +112,7 @@ public abstract class EntityDamageInterceptor {
     }
 
     @Unique
-    private static void formatReason(Object[] hook, Player player,
+    private static void formatReason(Object[] hook, PlayerRef playerRef,
                                      UUID attackerUuid, UUID targetUuid, String worldName,
                                      int x, int y, int z) {
         try {
@@ -124,7 +123,7 @@ public abstract class EntityDamageInterceptor {
             Object fmtHandle = getBridge(15);
             if (fmtHandle instanceof MethodHandle mh) {
                 Message msg = (Message) mh.invoke(raw);
-                player.sendMessage(msg);
+                playerRef.sendMessage(msg);
             }
         } catch (Throwable t) {
             reportFault(t);
@@ -197,10 +196,7 @@ public abstract class EntityDamageInterceptor {
 
             if (verdict == 1 || verdict == 2 || verdict == 3) {
                 if (verdict == 1) {
-                    Player player = commandBuffer.getComponent(attackerRef, Player.getComponentType());
-                    if (player != null) {
-                        formatReason(hook, player, attackerUuid, targetUuid, worldName, x, y, z);
-                    }
+                    formatReason(hook, attackerPlayerRef, attackerUuid, targetUuid, worldName, x, y, z);
                 }
                 context.getState().state = InteractionState.Failed;
                 return null; // Return null to trigger the existing null-check early exit in tick0

--- a/src/main/java/com/hyperprotect/mixin/intercept/combat/ProjectileLaunchInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/combat/ProjectileLaunchInterceptor.java
@@ -1,8 +1,10 @@
 package com.hyperprotect.mixin.intercept.combat;
 
+import com.hypixel.hytale.component.AddReason;
 import com.hypixel.hytale.component.CommandBuffer;
+import com.hypixel.hytale.component.Holder;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.core.modules.projectile.config.ProjectileConfig;
@@ -97,19 +99,30 @@ public class ProjectileLaunchInterceptor {
     }
 
     /**
-     * Redirect spawnProjectile to gate projectile launches through the hook.
-     * Returns null to indicate the projectile should not be spawned.
+     * Gate projectile launches by redirecting the {@code commandBuffer.addEntity(holder, SPAWN)}
+     * call inside the 6-arg {@code ProjectileModule.spawnProjectile(UUID, ...)} overload — the
+     * point where all launch paths converge to create the projectile entity. Both the 5-arg
+     * overload and direct callers (e.g. ProjectileInteraction) funnel through this method, so
+     * redirecting the entity creation here catches every launch. Returning null skips entity
+     * creation (the projectile is not spawned); the launching method ignores the returned ref
+     * for predicted launches, so this cleanly cancels the projectile.
+     *
+     * <p>The launching player's UUID + world are read from the enclosing method's
+     * {@code creatorRef}/{@code commandBuffer}; the spawn position from {@code position}.
      */
     @Redirect(
-        method = "*",
+        method = "spawnProjectile(Ljava/util/UUID;Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/CommandBuffer;Lcom/hypixel/hytale/server/core/modules/projectile/config/ProjectileConfig;Lorg/joml/Vector3d;Lorg/joml/Vector3d;)Lcom/hypixel/hytale/component/Ref;",
         at = @At(
             value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/modules/projectile/ProjectileModule;spawnProjectile(Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/component/CommandBuffer;Lcom/hypixel/hytale/server/core/modules/projectile/config/ProjectileConfig;Lcom/hypixel/hytale/math/vector/Vector3d;Lcom/hypixel/hytale/math/vector/Vector3d;)Lcom/hypixel/hytale/component/Ref;"
+            target = "Lcom/hypixel/hytale/component/CommandBuffer;addEntity(Lcom/hypixel/hytale/component/Holder;Lcom/hypixel/hytale/component/AddReason;)Lcom/hypixel/hytale/component/Ref;"
         ),
         require = 0
     )
-    private static Ref<EntityStore> gateProjectileLaunch(
-            ProjectileModule module,
+    private Ref<EntityStore> gateProjectileLaunch(
+            CommandBuffer<EntityStore> buffer,
+            Holder<EntityStore> holder,
+            AddReason reason,
+            UUID predictionId,
             Ref<EntityStore> creatorRef,
             CommandBuffer<EntityStore> commandBuffer,
             ProjectileConfig config,
@@ -119,10 +132,10 @@ public class ProjectileLaunchInterceptor {
         try {
             Object[] hook = resolveHook();
             if (hook == null) {
-                return module.spawnProjectile(creatorRef, commandBuffer, config, position, direction);
+                return buffer.addEntity(holder, reason);
             }
 
-            // Get creator's player UUID
+            // Get creator's player UUID + world
             UUID playerUuid = null;
             String worldName = null;
             try {
@@ -140,7 +153,7 @@ public class ProjectileLaunchInterceptor {
 
             // Only gate player-launched projectiles
             if (playerUuid == null || worldName == null) {
-                return module.spawnProjectile(creatorRef, commandBuffer, config, position, direction);
+                return buffer.addEntity(holder, reason);
             }
 
             int x = (int) position.x;
@@ -151,13 +164,13 @@ public class ProjectileLaunchInterceptor {
                     hook[0], playerUuid, worldName, x, y, z);
 
             if (verdict > 0) {
-                return null; // DENY — don't spawn projectile
+                return null; // DENY — don't create the projectile entity
             }
         } catch (Throwable t) {
             reportFault(t);
             // Fail-open: allow launch
         }
 
-        return module.spawnProjectile(creatorRef, commandBuffer, config, position, direction);
+        return buffer.addEntity(holder, reason);
     }
 }

--- a/src/main/java/com/hyperprotect/mixin/intercept/commands/CommandGateInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/commands/CommandGateInterceptor.java
@@ -4,6 +4,7 @@ import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.command.system.CommandManager;
 import com.hypixel.hytale.server.core.command.system.CommandSender;
 import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -102,7 +103,7 @@ public abstract class CommandGateInterceptor {
     }
 
     @Unique
-    private static void formatReason(Object[] hook, Player player, String commandString) {
+    private static void formatReason(Object[] hook, Player player, PlayerRef playerRef, String commandString) {
         try {
             if (hook.length < 3 || hook[2] == null) return;
             String raw = (String) ((MethodHandle) hook[2]).invoke(hook[0], player, commandString);
@@ -110,7 +111,7 @@ public abstract class CommandGateInterceptor {
             Object fmtHandle = getBridge(15);
             if (fmtHandle instanceof MethodHandle mh) {
                 Message msg = (Message) mh.invoke(raw);
-                player.sendMessage(msg);
+                playerRef.sendMessage(msg);
             }
         } catch (Throwable t) {
             reportFault(t);
@@ -143,9 +144,15 @@ public abstract class CommandGateInterceptor {
         // Always perform the real null check first
         Objects.requireNonNull(commandSender, message);
 
-        // Only gate player commands
-        if (!(sender instanceof Player player)) {
-            return commandSender; // Console commands pass through
+        // Only gate player commands. In 0.5.3 the command sender is a PlayerRef
+        // (Player is no longer a CommandSender); resolve the Player component so the
+        // bridge hook contract evaluateCommand(Player, String) stays unchanged.
+        if (!(sender instanceof PlayerRef playerRef)) {
+            return commandSender; // Console / non-player senders pass through
+        }
+        Player player = playerRef.getComponent(Player.getComponentType());
+        if (player == null) {
+            return commandSender; // Can't resolve Player — fail-open
         }
 
         try {
@@ -160,7 +167,7 @@ public abstract class CommandGateInterceptor {
             switch (verdict) {
                 case 0 -> { /* ALLOW */ }
                 case 1 -> {
-                    formatReason(hook, player, commandString);
+                    formatReason(hook, player, playerRef, commandString);
                     denied.set(new DeniedResult(CompletableFuture.completedFuture(null)));
                     return commandSender;
                 }

--- a/src/main/java/com/hyperprotect/mixin/intercept/containers/BarterTradeInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/containers/BarterTradeInterceptor.java
@@ -3,7 +3,6 @@ package com.hyperprotect.mixin.intercept.containers;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.server.core.Message;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.builtin.adventure.shop.barter.BarterPage;
@@ -169,10 +168,10 @@ public class BarterTradeInterceptor {
                         if (reason != null && !reason.isEmpty()) {
                             Object fmtHandle = getBridge(15);
                             if (fmtHandle instanceof MethodHandle mh) {
-                                Player player = store.getComponent(ref, Player.getComponentType());
-                                if (player != null) {
+                                PlayerRef pr = store.getComponent(ref, PlayerRef.getComponentType());
+                                if (pr != null) {
                                     Message msg = (Message) mh.invoke(reason);
-                                    player.sendMessage(msg);
+                                    pr.sendMessage(msg);
                                 }
                             }
                         }

--- a/src/main/java/com/hyperprotect/mixin/intercept/containers/CraftingGateInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/containers/CraftingGateInterceptor.java
@@ -5,7 +5,6 @@ import com.hypixel.hytale.component.ComponentAccessor;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.asset.type.item.config.CraftingRecipe;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import org.spongepowered.asm.mixin.Mixin;
@@ -159,7 +158,7 @@ public abstract class CraftingGateInterceptor {
     }
 
     @Unique
-    private static void formatReason(Object[] hook, Player player,
+    private static void formatReason(Object[] hook, PlayerRef playerRef,
                                      UUID playerUuid, String worldName,
                                      int x, int y, int z) {
         try {
@@ -170,7 +169,7 @@ public abstract class CraftingGateInterceptor {
             Object fmtHandle = getBridge(15);
             if (fmtHandle instanceof MethodHandle mh) {
                 Message msg = (Message) mh.invoke(raw);
-                player.sendMessage(msg);
+                playerRef.sendMessage(msg);
             }
         } catch (Throwable t) {
             reportFault(t);
@@ -222,11 +221,8 @@ public abstract class CraftingGateInterceptor {
 
                 if (verdict >= 1 && verdict <= 3) {
                     if (verdict == 1) {
-                        Player player = componentAccessor.getComponent(ref, Player.getComponentType());
-                        if (player != null) {
-                            formatReason(hook, player, playerUuid, worldName,
-                                    this.x, this.y, this.z);
-                        }
+                        formatReason(hook, playerRef, playerUuid, worldName,
+                                this.x, this.y, this.z);
                     }
                     return false; // Deny crafting
                 }

--- a/src/main/java/com/hyperprotect/mixin/intercept/entities/ChunkSpawnGate.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/entities/ChunkSpawnGate.java
@@ -142,7 +142,7 @@ public class ChunkSpawnGate {
             }
         }
 
-        String worldName = context.world != null ? context.world.getName() : null;
+        String worldName = context.getWorld() != null ? context.getWorld().getName() : null;
         if (worldName == null) return 0;
 
         int x = (int) context.xSpawn;

--- a/src/main/java/com/hyperprotect/mixin/intercept/entities/MarkerSpawnGate.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/entities/MarkerSpawnGate.java
@@ -142,7 +142,7 @@ public class MarkerSpawnGate {
             }
         }
 
-        String worldName = context.world != null ? context.world.getName() : null;
+        String worldName = context.getWorld() != null ? context.getWorld().getName() : null;
         if (worldName == null) return 0;
 
         int x = (int) context.xSpawn;

--- a/src/main/java/com/hyperprotect/mixin/intercept/entities/MountInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/entities/MountInterceptor.java
@@ -2,13 +2,12 @@ package com.hyperprotect.mixin.intercept.entities;
 
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.protocol.InteractionState;
 import com.hypixel.hytale.protocol.InteractionType;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.entity.EntitySnapshot;
 import com.hypixel.hytale.server.core.entity.InteractionContext;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.CooldownHandler;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.World;
@@ -176,11 +175,8 @@ public abstract class MountInterceptor {
                         if (reason != null && !reason.isEmpty()) {
                             Object fmtHandle = getBridge(15);
                             if (fmtHandle instanceof MethodHandle mh) {
-                                Player player = commandBuffer.getComponent(playerRef, Player.getComponentType());
-                                if (player != null) {
-                                    Message msg = (Message) mh.invoke(reason);
-                                    player.sendMessage(msg);
-                                }
+                                Message msg = (Message) mh.invoke(reason);
+                                pRef.sendMessage(msg);
                             }
                         }
                     } catch (Throwable ignored) {}

--- a/src/main/java/com/hyperprotect/mixin/intercept/entities/NpcAdditionGate.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/entities/NpcAdditionGate.java
@@ -4,7 +4,7 @@ import com.hypixel.hytale.component.AddReason;
 import com.hypixel.hytale.component.Holder;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.npc.NPCPlugin;
@@ -50,7 +50,7 @@ public class NpcAdditionGate {
     }
 
     @Redirect(
-        method = "spawnEntity(Lcom/hypixel/hytale/component/Store;ILcom/hypixel/hytale/math/vector/Vector3d;Lcom/hypixel/hytale/math/vector/Vector3f;Lcom/hypixel/hytale/server/core/asset/type/model/config/Model;Lcom/hypixel/hytale/function/consumer/TriConsumer;Lcom/hypixel/hytale/function/consumer/TriConsumer;)Lit/unimi/dsi/fastutil/Pair;",
+        method = "spawnEntity(Lcom/hypixel/hytale/component/Store;ILorg/joml/Vector3dc;Lcom/hypixel/hytale/math/vector/Rotation3fc;Lcom/hypixel/hytale/server/core/asset/type/model/config/Model;Lcom/hypixel/hytale/function/consumer/TriConsumer;Lcom/hypixel/hytale/function/consumer/TriConsumer;)Lit/unimi/dsi/fastutil/Pair;",
         at = @At(
             value = "INVOKE",
             target = "Lcom/hypixel/hytale/component/Store;addEntity(Lcom/hypixel/hytale/component/Holder;Lcom/hypixel/hytale/component/AddReason;)Lcom/hypixel/hytale/component/Ref;"
@@ -103,9 +103,9 @@ public class NpcAdditionGate {
                     }
                 }
             }
-            int x = (int) Math.floor(position.getX());
-            int y = (int) Math.floor(position.getY());
-            int z = (int) Math.floor(position.getZ());
+            int x = (int) Math.floor(position.x());
+            int y = (int) Math.floor(position.y());
+            int z = (int) Math.floor(position.z());
             int verdict = (int) cachedCheckHandle.invoke(hook, worldName, x, y, z);
             return verdict > 0;
         } catch (Throwable t) {

--- a/src/main/java/com/hyperprotect/mixin/intercept/entities/RespawnInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/entities/RespawnInterceptor.java
@@ -6,7 +6,7 @@ import com.hypixel.hytale.component.ComponentType;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.math.shape.Box;
 import com.hypixel.hytale.math.vector.Transform;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.entity.entities.player.data.PlayerRespawnPointData;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
@@ -69,7 +69,7 @@ public class RespawnInterceptor {
     @Shadow
     private static CompletableFuture<Transform> tryUseSpawnPoint(
             World world, List<PlayerRespawnPointData> sortedRespawnPoints,
-            int index, Ref<EntityStore> ref, Player playerComponent, Box boundingBox) {
+            int index, Ref<EntityStore> ref, PlayerRef playerComponent, Box boundingBox) {
         throw new AssertionError();
     }
 
@@ -157,9 +157,9 @@ public class RespawnInterceptor {
             TransformComponent transform = typedCa.getComponent(typedRef, TransformComponent.getComponentType());
             if (transform != null) {
                 Vector3d pos = transform.getPosition();
-                deathX = (int) pos.getX();
-                deathY = (int) pos.getY();
-                deathZ = (int) pos.getZ();
+                deathX = (int) pos.x();
+                deathY = (int) pos.y();
+                deathZ = (int) pos.z();
             }
 
             double[] override = (double[]) ((MethodHandle) hook[1]).invoke(
@@ -208,11 +208,11 @@ public class RespawnInterceptor {
     @Redirect(
         method = "getRespawnPosition",
         at = @At(value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/entity/entities/Player;tryUseSpawnPoint(Lcom/hypixel/hytale/server/core/universe/world/World;Ljava/util/List;ILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/entity/entities/Player;Lcom/hypixel/hytale/math/shape/Box;)Ljava/util/concurrent/CompletableFuture;")
+            target = "Lcom/hypixel/hytale/server/core/entity/entities/Player;tryUseSpawnPoint(Lcom/hypixel/hytale/server/core/universe/world/World;Ljava/util/List;ILcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/universe/PlayerRef;Lcom/hypixel/hytale/math/shape/Box;)Ljava/util/concurrent/CompletableFuture;")
     )
     private static CompletableFuture<Transform> interceptTryUseSpawnPoint(
             World world, List<PlayerRespawnPointData> sortedRespawnPoints,
-            int index, Ref<EntityStore> ref, Player playerComponent, Box boundingBox) {
+            int index, Ref<EntityStore> ref, PlayerRef playerComponent, Box boundingBox) {
         Transform override = respawnOverride.get();
         if (override != null) {
             respawnOverride.remove();

--- a/src/main/java/com/hyperprotect/mixin/intercept/interaction/CaptureCrateGate.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/interaction/CaptureCrateGate.java
@@ -3,7 +3,7 @@ package com.hyperprotect.mixin.intercept.interaction;
 import com.hypixel.hytale.builtin.adventure.farming.interactions.UseCaptureCrateInteraction;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.protocol.InteractionState;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.entity.InteractionContext;
@@ -116,7 +116,7 @@ public abstract class CaptureCrateGate {
     }
 
     @Unique
-    private static void sendDenyMessage(Object[] hook, Player player,
+    private static void sendDenyMessage(Object[] hook, PlayerRef playerRef,
                                          UUID playerUuid, String worldName,
                                          int x, int y, int z) {
         try {
@@ -127,7 +127,7 @@ public abstract class CaptureCrateGate {
             Object fmtHandle = getBridge(15);
             if (fmtHandle instanceof MethodHandle mh) {
                 Message msg = (Message) mh.invoke(raw);
-                player.sendMessage(msg);
+                playerRef.sendMessage(msg);
             }
         } catch (Throwable t) {
             reportFault(t);
@@ -176,12 +176,12 @@ public abstract class CaptureCrateGate {
 
                                     int verdict = (int) ((MethodHandle) hook[1]).invoke(
                                             hook[0], playerUuid, worldName,
-                                            (int) pos.getX(), (int) pos.getY(), (int) pos.getZ());
+                                            (int) pos.x(), (int) pos.y(), (int) pos.z());
 
                                     if (verdict >= 1 && verdict <= 3) {
                                         if (verdict == 1) {
-                                            sendDenyMessage(hook, player, playerUuid, worldName,
-                                                    (int) pos.getX(), (int) pos.getY(), (int) pos.getZ());
+                                            sendDenyMessage(hook, playerRef, playerUuid, worldName,
+                                                    (int) pos.x(), (int) pos.y(), (int) pos.z());
                                         }
                                         // Return null — existing code sets InteractionState.Failed
                                         return null;

--- a/src/main/java/com/hyperprotect/mixin/intercept/interaction/SimpleBlockInteractionGate.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/interaction/SimpleBlockInteractionGate.java
@@ -2,7 +2,7 @@ package com.hyperprotect.mixin.intercept.interaction;
 
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3i;
+import org.joml.Vector3i;
 import com.hypixel.hytale.protocol.InteractionState;
 import com.hypixel.hytale.protocol.InteractionType;
 import com.hypixel.hytale.server.core.Message;
@@ -220,7 +220,7 @@ public abstract class SimpleBlockInteractionGate {
     }
 
     @Unique
-    private static void sendDenyMessage(Object[] hook, Player player,
+    private static void sendDenyMessage(Object[] hook, PlayerRef playerRef,
                                          UUID playerUuid, String worldName,
                                          int x, int y, int z) {
         try {
@@ -240,7 +240,7 @@ public abstract class SimpleBlockInteractionGate {
             Object fmtHandle = getBridge(15);
             if (fmtHandle instanceof MethodHandle mh) {
                 Message msg = (Message) mh.invoke(raw);
-                player.sendMessage(msg);
+                playerRef.sendMessage(msg);
             }
         } catch (Throwable t) {
             reportFault(t);
@@ -257,7 +257,7 @@ public abstract class SimpleBlockInteractionGate {
     @Redirect(
         method = "tick0",
         at = @At(value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/modules/interaction/interaction/config/client/SimpleBlockInteraction;interactWithBlock(Lcom/hypixel/hytale/server/core/universe/world/World;Lcom/hypixel/hytale/component/CommandBuffer;Lcom/hypixel/hytale/protocol/InteractionType;Lcom/hypixel/hytale/server/core/entity/InteractionContext;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/math/vector/Vector3i;Lcom/hypixel/hytale/server/core/modules/interaction/interaction/CooldownHandler;)V")
+            target = "Lcom/hypixel/hytale/server/core/modules/interaction/interaction/config/client/SimpleBlockInteraction;interactWithBlock(Lcom/hypixel/hytale/server/core/universe/world/World;Lcom/hypixel/hytale/component/CommandBuffer;Lcom/hypixel/hytale/protocol/InteractionType;Lcom/hypixel/hytale/server/core/entity/InteractionContext;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lorg/joml/Vector3i;Lcom/hypixel/hytale/server/core/modules/interaction/interaction/CooldownHandler;)V")
     )
     private void gateBlockInteraction(SimpleBlockInteraction self,
                                        World world, CommandBuffer<EntityStore> commandBuffer,
@@ -275,9 +275,9 @@ public abstract class SimpleBlockInteractionGate {
                     if (playerRef != null) {
                         UUID playerUuid = playerRef.getUuid();
                         String worldName = world.getName();
-                        int x = targetBlock.getX();
-                        int y = targetBlock.getY();
-                        int z = targetBlock.getZ();
+                        int x = targetBlock.x();
+                        int y = targetBlock.y();
+                        int z = targetBlock.z();
 
                         // Pass interaction class name to hook for debug logging
                         System.getProperties().put("hyperprotect.context.interaction", className);
@@ -305,7 +305,7 @@ public abstract class SimpleBlockInteractionGate {
 
                         if (verdict >= 1 && verdict <= 3) {
                             if (verdict == 1) {
-                                sendDenyMessage(hook, player, playerUuid, worldName, x, y, z);
+                                sendDenyMessage(hook, playerRef, playerUuid, worldName, x, y, z);
                             }
                             context.getState().state = InteractionState.Failed;
                             return; // DENIED

--- a/src/main/java/com/hyperprotect/mixin/intercept/interaction/SimpleInstantInteractionGate.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/interaction/SimpleInstantInteractionGate.java
@@ -2,7 +2,7 @@ package com.hyperprotect.mixin.intercept.interaction;
 
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Ref;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.protocol.InteractionState;
 import com.hypixel.hytale.protocol.InteractionType;
 import com.hypixel.hytale.server.core.Message;
@@ -162,7 +162,7 @@ public abstract class SimpleInstantInteractionGate {
     }
 
     @Unique
-    private static void sendDenyMessage(Object[] hook, Player player,
+    private static void sendDenyMessage(Object[] hook, PlayerRef playerRef,
                                          UUID playerUuid, String worldName,
                                          int x, int y, int z) {
         try {
@@ -173,7 +173,7 @@ public abstract class SimpleInstantInteractionGate {
             Object fmtHandle = getBridge(15);
             if (fmtHandle instanceof MethodHandle mh) {
                 Message msg = (Message) mh.invoke(raw);
-                player.sendMessage(msg);
+                playerRef.sendMessage(msg);
             }
         } catch (Throwable t) {
             reportFault(t);
@@ -256,17 +256,17 @@ public abstract class SimpleInstantInteractionGate {
                                 if (useDoubles) {
                                     verdict = (int) ((MethodHandle) hook[1]).invoke(
                                             hook[0], playerUuid, worldName,
-                                            pos.getX(), pos.getY(), pos.getZ());
+                                            pos.x(), pos.y(), pos.z());
                                 } else {
                                     verdict = (int) ((MethodHandle) hook[1]).invoke(
                                             hook[0], playerUuid, worldName,
-                                            (int) pos.getX(), (int) pos.getY(), (int) pos.getZ());
+                                            (int) pos.x(), (int) pos.y(), (int) pos.z());
                                 }
 
                                 if (verdict >= 1 && verdict <= 3) {
                                     if (verdict == 1) {
-                                        sendDenyMessage(hook, player, playerUuid, worldName,
-                                                (int) pos.getX(), (int) pos.getY(), (int) pos.getZ());
+                                        sendDenyMessage(hook, playerRef, playerUuid, worldName,
+                                                (int) pos.x(), (int) pos.y(), (int) pos.z());
                                     }
                                     context.getState().state = InteractionState.Failed;
                                     return; // DENIED

--- a/src/main/java/com/hyperprotect/mixin/intercept/items/DeathLootInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/items/DeathLootInterceptor.java
@@ -10,7 +10,7 @@ import com.hypixel.hytale.server.core.modules.entity.damage.DeathComponent;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -137,7 +137,7 @@ public abstract class DeathLootInterceptor {
 
             int verdict = (int) ((MethodHandle) hook[1]).invoke(
                     hook[0], playerUuid, worldName,
-                    (int) pos.getX(), (int) pos.getY(), (int) pos.getZ());
+                    (int) pos.x(), (int) pos.y(), (int) pos.z());
 
             // Verdict 0 = ALLOW (drop normally), anything else = keep inventory
             if (verdict != 0) {

--- a/src/main/java/com/hyperprotect/mixin/intercept/items/ProximityLootInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/items/ProximityLootInterceptor.java
@@ -5,7 +5,7 @@ import com.hypixel.hytale.component.Resource;
 import com.hypixel.hytale.component.ResourceType;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.component.spatial.SpatialStructure;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
 import com.hypixel.hytale.server.core.modules.entity.player.PlayerItemEntityPickupSystem;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
@@ -139,7 +139,7 @@ public abstract class ProximityLootInterceptor {
         method = "tick",
         at = @At(
             value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/modules/entity/component/TransformComponent;getPosition()Lcom/hypixel/hytale/math/vector/Vector3d;",
+            target = "Lcom/hypixel/hytale/server/core/modules/entity/component/TransformComponent;getPosition()Lorg/joml/Vector3d;",
             ordinal = 0
         )
     )
@@ -156,7 +156,7 @@ public abstract class ProximityLootInterceptor {
      */
     @Redirect(
         method = "tick",
-        at = @At(value = "INVOKE", target = "Lcom/hypixel/hytale/component/spatial/SpatialStructure;closest(Lcom/hypixel/hytale/math/vector/Vector3d;)Ljava/lang/Object;")
+        at = @At(value = "INVOKE", target = "Lcom/hypixel/hytale/component/spatial/SpatialStructure;closest(Lorg/joml/Vector3d;)Ljava/lang/Object;")
     )
     private Object gateAction(SpatialStructure<?> spatialStructure, Vector3d position) {
         Object result = spatialStructure.closest(position);
@@ -197,7 +197,7 @@ public abstract class ProximityLootInterceptor {
 
             int verdict = (int) ((MethodHandle) hook[1]).invoke(
                     hook[0], playerRef.getUuid(), worldName,
-                    itemPos.getX(), itemPos.getY(), itemPos.getZ());
+                    itemPos.x(), itemPos.y(), itemPos.z());
 
             // Any non-zero positive verdict = deny (silent, no messaging for auto pickup)
             if (verdict > ALLOW) {

--- a/src/main/java/com/hyperprotect/mixin/intercept/items/WearInterceptor.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/items/WearInterceptor.java
@@ -2,8 +2,8 @@ package com.hyperprotect.mixin.intercept.items;
 
 import com.hypixel.hytale.component.ComponentAccessor;
 import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.server.core.entity.ItemUtils;
 import com.hypixel.hytale.server.core.entity.LivingEntity;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
 import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
@@ -11,7 +11,7 @@ import com.hypixel.hytale.server.core.inventory.transaction.ItemStackSlotTransac
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
-import com.hypixel.hytale.math.vector.Vector3d;
+import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,14 +27,16 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
- * Intercepts durability changes on Player.updateItemStackDurability().
- * Redirects the super.updateItemStackDurability() call — returns null
- * (no transaction = no durability change) when the hook denies.
+ * Intercepts durability changes in LivingEntity.updateItemStackDurability().
+ * Redirects the inner {@code ItemUtils.updateItemStackDurability(...)} call —
+ * returns null (no transaction = no durability change) when the hook denies.
  *
- * <p>On the allow path, the LivingEntity super logic is inlined directly
- * rather than calling {@code instance.updateItemStackDurability()}, because
- * INVOKEVIRTUAL would dispatch back to Player's override and re-trigger
- * this redirect (infinite recursion → StackOverflowError).
+ * <p>In 0.5.3 {@code Player} no longer overrides {@code updateItemStackDurability}
+ * and the durability logic moved out of the entity hierarchy into the static
+ * {@code ItemUtils.updateItemStackDurability}. {@code LivingEntity.updateItemStackDurability}
+ * now simply delegates to it, so this mixin targets {@code LivingEntity} and redirects
+ * that static call. The hook only fires for players (non-player entities pass through),
+ * and the allow path re-invokes the static impl — there is no recursion risk.
  *
  * <p>Hook contract (durability slot):
  * <pre>
@@ -44,7 +46,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  *
  * <p>No messaging needed — durability is a passive mechanic.
  */
-@Mixin(Player.class)
+@Mixin(LivingEntity.class)
 public abstract class WearInterceptor {
 
     @Unique
@@ -104,26 +106,26 @@ public abstract class WearInterceptor {
     }
 
     /**
-     * Redirect the super.updateItemStackDurability() call inside Player.updateItemStackDurability().
+     * Redirect the {@code ItemUtils.updateItemStackDurability(...)} call inside
+     * {@code LivingEntity.updateItemStackDurability()}.
      * If the hook denies, return null (no transaction = durability unchanged).
-     * Otherwise, inline the LivingEntity super logic directly.
+     * Otherwise, invoke the real static durability impl.
      *
-     * <p>We cannot call {@code instance.updateItemStackDurability()} on the allow path
-     * because INVOKEVIRTUAL dispatches to Player (which contains this redirect),
-     * causing infinite recursion. Instead we inline LivingEntity's implementation:
-     * {@code itemStack.withIncreasedDurability()} + {@code container.replaceItemStackInSlot()}.
+     * <p>The redirected call is a plain static method on a different class
+     * ({@code ItemUtils}), so re-invoking it on the allow path cannot re-enter this
+     * redirect — no recursion risk.
      */
     @Redirect(
         method = "updateItemStackDurability",
         at = @At(
             value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/entity/LivingEntity;updateItemStackDurability(Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/server/core/inventory/container/ItemContainer;IDLcom/hypixel/hytale/component/ComponentAccessor;)Lcom/hypixel/hytale/server/core/inventory/transaction/ItemStackSlotTransaction;"
+            target = "Lcom/hypixel/hytale/server/core/entity/ItemUtils;updateItemStackDurability(Lcom/hypixel/hytale/component/Ref;Lcom/hypixel/hytale/server/core/inventory/ItemStack;Lcom/hypixel/hytale/server/core/inventory/container/ItemContainer;IDLcom/hypixel/hytale/component/ComponentAccessor;)Lcom/hypixel/hytale/server/core/inventory/transaction/ItemStackSlotTransaction;"
         ),
         require = 0
     )
     @Nullable
     private ItemStackSlotTransaction interceptUpdateDurability(
-            LivingEntity instance, @Nonnull Ref<EntityStore> ref, @Nonnull ItemStack itemStack,
+            @Nonnull Ref<EntityStore> ref, @Nonnull ItemStack itemStack,
             ItemContainer container, int slotId, double durabilityChange,
             @Nonnull ComponentAccessor<EntityStore> componentAccessor) {
         try {
@@ -141,7 +143,7 @@ public abstract class WearInterceptor {
 
                             int verdict = (int) ((MethodHandle) hook[1]).invoke(
                                     hook[0], playerUuid, worldName,
-                                    (int) pos.getX(), (int) pos.getY(), (int) pos.getZ());
+                                    (int) pos.x(), (int) pos.y(), (int) pos.z());
 
                             if (verdict != 0) {
                                 return null; // Deny: no transaction = no durability change
@@ -155,10 +157,8 @@ public abstract class WearInterceptor {
             // Fail-open: allow normal durability behavior
         }
 
-        // Allow: inline LivingEntity.updateItemStackDurability() directly.
-        // Cannot call instance.updateItemStackDurability() — INVOKEVIRTUAL would
-        // dispatch to Player's override and re-enter this redirect.
-        ItemStack updatedItemStack = itemStack.withIncreasedDurability(durabilityChange);
-        return container.replaceItemStackInSlot((short) slotId, itemStack, updatedItemStack);
+        // Allow: invoke the real static durability impl. Because ItemUtils is a
+        // different class, this does not re-enter the redirect (no recursion).
+        return ItemUtils.updateItemStackDurability(ref, itemStack, container, slotId, durabilityChange, componentAccessor);
     }
 }

--- a/src/main/java/com/hyperprotect/mixin/intercept/logging/ChainDesyncFilter.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/logging/ChainDesyncFilter.java
@@ -93,7 +93,7 @@ public class ChainDesyncFilter {
     }
 
     @Redirect(
-        method = "addTempSyncData",
+        method = "putInteractionSyncData",
         at = @At(
             value = "INVOKE",
             target = "Lcom/hypixel/hytale/logger/HytaleLogger;at(Ljava/util/logging/Level;)Lcom/hypixel/hytale/logger/HytaleLogger$Api;"

--- a/src/main/java/com/hyperprotect/mixin/intercept/worldmap/MapMarkerFilter.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/worldmap/MapMarkerFilter.java
@@ -133,7 +133,7 @@ public class MapMarkerFilter {
         method = "update",
         at = @At(
             value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/universe/world/worldmap/markers/MarkersCollector;addIgnoreViewDistance(Lcom/hypixel/hytale/server/core/universe/world/worldmap/MapMarker;)V"
+            target = "Lcom/hypixel/hytale/server/core/universe/world/worldmap/markers/MarkersCollector;addIgnoreViewDistance(Lcom/hypixel/hytale/protocol/packets/worldmap/MapMarker;)V"
         ),
         require = 0
     )

--- a/src/main/java/com/hyperprotect/mixin/intercept/worldmap/SharedMarkerFilter.java
+++ b/src/main/java/com/hyperprotect/mixin/intercept/worldmap/SharedMarkerFilter.java
@@ -134,7 +134,7 @@ public class SharedMarkerFilter {
         method = "update",
         at = @At(
             value = "INVOKE",
-            target = "Lcom/hypixel/hytale/server/core/universe/world/worldmap/markers/MarkersCollector;add(Lcom/hypixel/hytale/protocol/packets/worldmap/MapMarker;)V"
+            target = "Lcom/hypixel/hytale/server/core/universe/world/worldmap/markers/MarkersCollector;addIgnoreViewDistance(Lcom/hypixel/hytale/protocol/packets/worldmap/MapMarker;)V"
         ),
         require = 0
     )
@@ -143,19 +143,19 @@ public class SharedMarkerFilter {
         try {
             Object[] hook = resolveHook();
             if (hook == null) {
-                collector.add(marker); // No hook — show (original behavior)
+                collector.addIgnoreViewDistance(marker); // No hook — show (original behavior)
                 return;
             }
 
             UUID creatorUuid = extractCreatorUuid(marker);
             if (creatorUuid == null) {
-                collector.add(marker); // Unknown creator — show (fail-open)
+                collector.addIgnoreViewDistance(marker); // Unknown creator — show (fail-open)
                 return;
             }
 
             UUID viewerUuid = player.getUuid();
             if (viewerUuid == null || viewerUuid.equals(creatorUuid)) {
-                collector.add(marker); // Self or unknown viewer — show
+                collector.addIgnoreViewDistance(marker); // Self or unknown viewer — show
                 return;
             }
 
@@ -172,12 +172,12 @@ public class SharedMarkerFilter {
                     hook[0], viewerUuid, creatorUuid, worldName, x, z);
 
             if (verdict <= 0) {
-                collector.add(marker); // SHOW
+                collector.addIgnoreViewDistance(marker); // SHOW
             }
             // verdict > 0 = HIDE (don't add marker)
         } catch (Throwable t) {
             reportFault(t);
-            collector.add(marker); // Fail-open: show marker
+            collector.addIgnoreViewDistance(marker); // Fail-open: show marker
         }
     }
 }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -4,7 +4,7 @@
   "Version": "${version}",
   "Description": "Generic server protection hooks via Hyxin mixins — any mod can register hook handlers",
   "Authors": [{"Name": "HyperSystems"}],
-  "ServerVersion": "${serverVersion}",
+  "ServerVersion": "^${serverVersion}",
   "Dependencies": {},
   "OptionalDependencies": {},
   "DisabledByDefault": false,


### PR DESCRIPTION
## Summary

Migrates HyperProtect-Mixin to the Hytale dedicated server **0.5.3** release (Java 25). 0.5.3
carried major internal API changes, so every one of the 29 mixin interceptors was re-verified
against the decompiled 0.5.3 source and `javap` on the live server jar — mixin target descriptors
are not validated by the compiler, and `defaultRequire: 1` makes a single wrong descriptor a hard
startup failure.

Builds against 0.5.3 and **loads on a live 0.5.3 server (Hyxin 0.0.11, standalone mode) with all 29
mixins active and zero apply failures.**

## Key API deltas handled

- **Vectors → JOML**: `com.hypixel.hytale.math.vector.Vector3d/3f/3i` → `org.joml.*`; accessors
  `getX/Y/Z()` → `x/y/z()`. (`Transform`, `Rotation3f`, and `Box` stay in `math.*`.)
- **`Player` is no longer a `CommandSender`**: `sendMessage`/`hasPermission` moved to `PlayerRef`;
  all deny messages now route through `PlayerRef`.
- **Manifest**: `ServerVersion` → `^0.5.3` (the 0.5.x SemverRange codec rejects a bare non-zero patch).

## Per-subsystem descriptor / handler changes

**building**
- ExplosionInterceptor — the inner `performBlockDamage` dropped its leading `LivingEntity` param;
  rewrote both descriptors + the handler, with explosions detected via `ref == null`.
- BlockPlaceInterceptor — `placeBlock` is now 15 args (`Inventory` removed; `quickRetype`/`noPhysics`
  added; two `org.joml.Vector3i`); rewrote descriptor + pass-through.
- HarvestInterceptor — `removeBlock` / `interactivelyPickupItem` vectors → JOML; messages via `PlayerRef`.
- PasteInterceptor — message via the in-scope `PlayerRef`.

**items**
- WearInterceptor — `Player` no longer overrides `updateItemStackDurability`; the impl moved to the
  static `ItemUtils.updateItemStackDurability`. Retargeted `@Mixin(LivingEntity)` and redirect that static
  call (allow path re-invokes it — no recursion, the v1.2.4 inlining workaround is removed).
- ProximityLoot / DeathLoot — vectors → JOML.

**combat**
- ProjectileLaunchInterceptor — `spawnProjectile` gained a 6-arg `(UUID, …)` overload that the launch path
  calls directly while the 5-arg one only delegates to it; retargeted the 6-arg method and redirect its
  `commandBuffer.addEntity(holder, SPAWN)` convergence point (creator/world/position from enclosing params).
- EntityDamageInterceptor — `EntitySnapshot.getPosition` → JOML; message via `PlayerRef`.

**entities**
- NpcAdditionGate — `NPCPlugin.spawnEntity` now takes `org.joml.Vector3dc` + `Rotation3fc`.
- RespawnInterceptor — `Player.tryUseSpawnPoint`'s 5th param `Player` → `PlayerRef` (`@Shadow` + descriptor
  + handler).
- MarkerSpawnGate / ChunkSpawnGate — `SpawningContext.world` is now private → `getWorld()`.
- EntityLoadGate / PrefabSpawnInterceptor — descriptors verified unchanged.

**commands**
- CommandGateInterceptor — the command sender is now a `PlayerRef`; match it, resolve the `Player`
  component to keep the `evaluateCommand(Player, String)` bridge contract unchanged, message via `PlayerRef`.

**interaction**
- SimpleBlockInteractionGate — `interactWithBlock`'s `Vector3i` → JOML; message via `PlayerRef`.
- SimpleInstantInteractionGate / CaptureCrateGate — `getPosition` → JOML; messages via `PlayerRef`.

**worldmap**
- MapMarkerFilter — corrected the `MapMarker` package in the `addIgnoreViewDistance` descriptor.
- SharedMarkerFilter — `SharedMarkersProvider.update` now emits via `addIgnoreViewDistance` (not `add`);
  retargeted the redirect and the handler's re-emit calls.

**logging**
- ChainDesyncFilter — `InteractionChain.addTempSyncData` was renamed to `putInteractionSyncData`.
- FlameTickInterceptor, BenchPositionCapture, SpawnLogFilter, EntryDesyncFilter — no changes; descriptors
  verified unchanged on 0.5.3.

## Verification

- **Compile**: `./gradlew clean jar -Phytale_server_version=0.5.3` succeeds (only deprecation warnings for
  `getPlayerRef()` / `getUuid()`, both still present on 0.5.3).
- **Live load**: launched the 0.5.3 server with Hyxin 0.0.11 and `--accept-early-plugins` (standalone, no
  OrbisGuard). The early plugin loads, the config plugin reports `OrbisGuard-Mixins not detected — all
  mixins active`, the server reaches `Universe ready!` / `Booted!`, and a full-log scan finds **zero**
  `InvalidInjectionException` / `Critical injection` / `was not applied` / `target … not found` /
  `Mixin … failed`.
- The 30-slot bridge protocol, verdict contract, `SAFE_MIXINS` (14), and `totalMixins = 29` are unchanged
  (HyperFactions 0.14.0 consumes them).

## Still owed — interactive checklist

A headless boot proves the mixins **apply**; it does not prove each redirect **fires** at the right point.
The following need a human at a connected 0.5.3 client with HyperFactions 0.14.0 deployed to `mods/` (which
registers the bridge hooks):

- [x] Block break / place / use
- [x] PvP / PvE damage
- [ ] Explosion block damage
- [ ] Automatic + interactive item pickup
- [ ] Container access/open + crafting at a bench
- [ ] Projectile launch (bow/spell) gating
- [ ] Mount / seat
- [ ] Respawn-position override
- [ ] Death-drop prevention
- [ ] Durability protection
- [ ] Barter/trade + capture crate
- [ ] Mob / prefab / entity-load spawn gating
- [ ] World-map enemy + shared-marker filtering
- [ ] Command gating
- [ ] Builder-tools paste

Deployment note: HyperProtect-Mixin runs as an early plugin only (Hyxin loads its mixins; it cannot be a
`mods/` plugin because the mod classloader lacks Hyxin's Mixin library — by design). Essential bridge
initialization happens in the mixin config plugin's `onLoad`, which runs and was confirmed on 0.5.3;
HyperFactions registers its own format handle (slot 15), so deny messaging is unaffected.
